### PR TITLE
feat: external app launcher / opener

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -136,29 +136,23 @@ builder.SingleInstance("my-app-id", guard =>
 ---
 
 ### Opener (External App Launcher)
-**Status:** Not started
+**Status:** Complete
 **Platforms:** All
 **Complexity:** Low
 
-Open files, folders, and URLs in their default applications.
+Open files, folders, and URLs in their default applications. Uses `Process.Start` with `UseShellExecute = true` for cross-platform support, with platform-specific handling for `RevealInFileManager`.
 
-| Platform | API |
-|----------|-----|
-| Windows | ShellExecute |
-| macOS | NSWorkspace.open() |
-| Linux | xdg-open / gio open |
-
-**Proposed API:**
+**API:**
 ```csharp
 HermesApplication.OpenUrl("https://example.com");
 HermesApplication.OpenFile("/path/to/file.pdf");
 HermesApplication.RevealInFileManager("/path/to/file.txt");
 ```
 
-**Features needed:**
-- [ ] Open URL in default browser
-- [ ] Open file in default application
-- [ ] Reveal file/folder in file manager
+**Features:**
+- [x] Open URL in default browser (http/https only)
+- [x] Open file in default application
+- [x] Reveal file/folder in file manager
 
 ---
 

--- a/samples/BlazorHelloWorld/Pages/Opener.razor
+++ b/samples/BlazorHelloWorld/Pages/Opener.razor
@@ -1,0 +1,73 @@
+@page "/opener"
+
+<h1>Opener</h1>
+<p class="subtitle">Open files, URLs, and folders in their default applications</p>
+
+<div class="opener-section">
+    <h2>Open URL</h2>
+    <input type="text" @bind="_url" placeholder="https://example.com" />
+    <button @onclick="OnOpenUrl">Open in Browser</button>
+</div>
+
+<div class="opener-section">
+    <h2>Open File</h2>
+    <input type="text" @bind="_filePath" placeholder="/path/to/file.pdf" />
+    <button @onclick="OnOpenFile">Open File</button>
+</div>
+
+<div class="opener-section">
+    <h2>Reveal in File Manager</h2>
+    <input type="text" @bind="_revealPath" placeholder="/path/to/file.txt" />
+    <button @onclick="OnReveal">Reveal</button>
+</div>
+
+@if (_error is not null)
+{
+    <div class="error">@_error</div>
+}
+
+@code {
+    private string _url = "https://example.com";
+    private string _filePath = "";
+    private string _revealPath = "";
+    private string? _error;
+
+    private void OnOpenUrl()
+    {
+        _error = null;
+        try
+        {
+            HermesApplication.OpenUrl(_url);
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+    }
+
+    private void OnOpenFile()
+    {
+        _error = null;
+        try
+        {
+            HermesApplication.OpenFile(_filePath);
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+    }
+
+    private void OnReveal()
+    {
+        _error = null;
+        try
+        {
+            HermesApplication.RevealInFileManager(_revealPath);
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+    }
+}

--- a/samples/BlazorHelloWorld/Shared/NavMenu.razor
+++ b/samples/BlazorHelloWorld/Shared/NavMenu.razor
@@ -9,4 +9,7 @@
     <NavLink class="nav-link" href="jsinterop">
         JS Interop
     </NavLink>
+    <NavLink class="nav-link" href="opener">
+        Opener
+    </NavLink>
 </div>

--- a/src/Hermes/HermesApplication.cs
+++ b/src/Hermes/HermesApplication.cs
@@ -111,6 +111,33 @@ public static class HermesApplication
         return new SingleInstanceGuard(applicationId);
     }
 
+    /// <summary>
+    /// Opens a URL in the default browser.
+    /// Only http:// and https:// schemes are allowed.
+    /// </summary>
+    /// <param name="url">The URL to open.</param>
+    /// <exception cref="ArgumentException">Thrown when the URL is null, empty, or uses a disallowed scheme.</exception>
+    public static void OpenUrl(string url) => Opener.OpenUrl(url);
+
+    /// <summary>
+    /// Opens a file or directory in its default application.
+    /// Directories are opened in the default file manager.
+    /// </summary>
+    /// <param name="path">The path to the file or directory to open.</param>
+    /// <exception cref="ArgumentException">Thrown when the path is null or empty.</exception>
+    /// <exception cref="FileNotFoundException">Thrown when the path does not exist.</exception>
+    public static void OpenFile(string path) => Opener.OpenFile(path);
+
+    /// <summary>
+    /// Reveals a file or directory in the platform's file manager.
+    /// For files, the containing folder is opened and the file is selected (macOS and Windows).
+    /// On Linux, the containing directory is opened without file selection.
+    /// </summary>
+    /// <param name="path">The path to the file or directory to reveal.</param>
+    /// <exception cref="ArgumentException">Thrown when the path is null or empty.</exception>
+    /// <exception cref="FileNotFoundException">Thrown when the path does not exist.</exception>
+    public static void RevealInFileManager(string path) => Opener.RevealInFileManager(path);
+
     private static IDockMenuBackend? CreateDockMenuBackend()
     {
 #if MACOS

--- a/src/Hermes/Opener.cs
+++ b/src/Hermes/Opener.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Mythetech. Licensed under the Elastic License 2.0.
+using System.Diagnostics;
+
+namespace Hermes;
+
+/// <summary>
+/// Opens files, folders, and URLs in their default applications.
+/// </summary>
+public static class Opener
+{
+    private static readonly HashSet<string> AllowedUrlSchemes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "http", "https"
+    };
+
+    /// <summary>
+    /// Opens a URL in the default browser.
+    /// Only http:// and https:// schemes are allowed.
+    /// </summary>
+    /// <param name="url">The URL to open.</param>
+    /// <exception cref="ArgumentException">Thrown when the URL is null, empty, or uses a disallowed scheme.</exception>
+    public static void OpenUrl(string url)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(url);
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            throw new ArgumentException($"Invalid URL: {url}", nameof(url));
+
+        if (!AllowedUrlSchemes.Contains(uri.Scheme))
+            throw new ArgumentException($"URL scheme '{uri.Scheme}' is not allowed. Only http and https are supported.", nameof(url));
+
+        Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+    }
+
+    /// <summary>
+    /// Opens a file or directory in its default application.
+    /// Directories are opened in the default file manager.
+    /// </summary>
+    /// <param name="path">The path to the file or directory to open.</param>
+    /// <exception cref="ArgumentException">Thrown when the path is null or empty.</exception>
+    /// <exception cref="FileNotFoundException">Thrown when the path does not exist.</exception>
+    public static void OpenFile(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        if (!File.Exists(path) && !Directory.Exists(path))
+            throw new FileNotFoundException($"The path does not exist: {path}", path);
+
+        Process.Start(new ProcessStartInfo(path) { UseShellExecute = true });
+    }
+
+    /// <summary>
+    /// Reveals a file or directory in the platform's file manager.
+    /// For files, the containing folder is opened and the file is selected (macOS and Windows).
+    /// On Linux, the containing directory is opened without file selection.
+    /// For directories, the directory is opened directly.
+    /// </summary>
+    /// <param name="path">The path to the file or directory to reveal.</param>
+    /// <exception cref="ArgumentException">Thrown when the path is null or empty.</exception>
+    /// <exception cref="FileNotFoundException">Thrown when the path does not exist.</exception>
+    public static void RevealInFileManager(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        var isFile = File.Exists(path);
+        var isDirectory = Directory.Exists(path);
+
+        if (!isFile && !isDirectory)
+            throw new FileNotFoundException($"The path does not exist: {path}", path);
+
+        if (OperatingSystem.IsMacOS())
+        {
+            if (isFile)
+                Process.Start("open", ["-R", path]);
+            else
+                Process.Start("open", [path]);
+        }
+        else if (OperatingSystem.IsWindows())
+        {
+            if (isFile)
+                Process.Start("explorer", ["/select,", path]);
+            else
+                Process.Start("explorer", [path]);
+        }
+        else if (OperatingSystem.IsLinux())
+        {
+            var target = isFile ? Path.GetDirectoryName(path)! : path;
+            Process.Start("xdg-open", [target]);
+        }
+        else
+        {
+            throw new PlatformNotSupportedException("RevealInFileManager is not supported on this platform.");
+        }
+    }
+}

--- a/tests/Hermes.Tests/OpenerTests.cs
+++ b/tests/Hermes.Tests/OpenerTests.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Mythetech. Licensed under the Elastic License 2.0.
+using Xunit;
+
+namespace Hermes.Tests;
+
+public sealed class OpenerTests
+{
+    [Fact]
+    public void OpenUrl_Null_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => Opener.OpenUrl(null!));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void OpenUrl_Empty_ThrowsArgumentException(string url)
+    {
+        Assert.Throws<ArgumentException>(() => Opener.OpenUrl(url));
+    }
+
+    [Theory]
+    [InlineData("not-a-url")]
+    [InlineData("ftp://example.com")]
+    [InlineData("file:///etc/passwd")]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("data:text/html,<h1>hi</h1>")]
+    public void OpenUrl_DisallowedScheme_ThrowsArgumentException(string url)
+    {
+        Assert.Throws<ArgumentException>(() => Opener.OpenUrl(url));
+    }
+
+    [Theory]
+    [InlineData("http://example.com")]
+    [InlineData("https://example.com")]
+    [InlineData("HTTP://EXAMPLE.COM")]
+    [InlineData("HTTPS://EXAMPLE.COM")]
+    public void OpenUrl_ValidScheme_DoesNotThrowArgumentException(string url)
+    {
+        // These will attempt to launch a browser, so we just verify no ArgumentException.
+        // Process.Start may throw on CI without a desktop, so we catch non-argument exceptions.
+        try
+        {
+            Opener.OpenUrl(url);
+        }
+        catch (Exception ex) when (ex is not ArgumentException)
+        {
+            // Expected on headless environments
+        }
+    }
+
+    [Fact]
+    public void OpenFile_Null_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => Opener.OpenFile(null!));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void OpenFile_Empty_ThrowsArgumentException(string path)
+    {
+        Assert.Throws<ArgumentException>(() => Opener.OpenFile(path));
+    }
+
+    [Fact]
+    public void OpenFile_NonExistentPath_ThrowsFileNotFoundException()
+    {
+        Assert.Throws<FileNotFoundException>(() => Opener.OpenFile("/nonexistent/path/to/file.txt"));
+    }
+
+    [Fact]
+    public void RevealInFileManager_Null_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => Opener.RevealInFileManager(null!));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RevealInFileManager_Empty_ThrowsArgumentException(string path)
+    {
+        Assert.Throws<ArgumentException>(() => Opener.RevealInFileManager(path));
+    }
+
+    [Fact]
+    public void RevealInFileManager_NonExistentPath_ThrowsFileNotFoundException()
+    {
+        Assert.Throws<FileNotFoundException>(() => Opener.RevealInFileManager("/nonexistent/path/to/file.txt"));
+    }
+}


### PR DESCRIPTION
## Description

Adds external app launcher capabilities / opener

- Open URL (http/https only)
- Open File
- Reveal in File Manager

## Changes

 - C# API for the above
 - Updates BlazorHellowWorld sample with a new page to demo the functionality

## Platform Testing

<!-- Which platforms have you tested on? -->

- [x] Windows
- [x] macOS
- [x] Linux

## Checklist

- [x] I have tested my changes locally
- [x] I have added tests for new functionality (if applicable)
- [x] My changes build without warnings
- [x] I have updated documentation (if applicable)
